### PR TITLE
import Span from proc_macro2 instead of syn

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use syn::export::Span;
+use proc_macro2::Span;
 
 use crate::config::Config;
 use crate::meta;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ extern crate syn;
 extern crate quote;
 
 use proc_macro::TokenStream;
-use syn::export::Span;
+use proc_macro2::Span;
 use syn::*;
 
 mod config;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,5 +1,4 @@
-use proc_macro2::TokenStream;
-use syn::export::Span;
+use proc_macro2::{Span, TokenStream};
 use syn::*;
 
 use crate::config::Config;


### PR DESCRIPTION
appears to fix https://github.com/rust-bakery/nom-derive/issues/11