### PR TITLE
Dev/gen parse trait v0.1

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,56 @@
+## Upgrading to 0.9
+
+### Generalization of the Parse trait
+
+`nom-derive` now generates an implementation of the `Parse` trait when possible (when there are no selector or extra args).
+The methods `parse_be` and `parse_le` are both generated (unless endianness is fixed), and will recursively call
+similarly named methods in child objects.
+
+There are two possibilities:
+  - the object can be represented (and parsed) differently, depending on the endianness
+  - the object always have the same representation, and does not depend on the endianness (most common case)
+
+If the object always have the same parsing, then the endianness should be fixed. This can be done by using the `NomBE`
+or `NomLE` custom derive instead of `Nom`, or by applying the `BigEndian` or `LittleEndian` top-level attributes.
+
+If the object can has different representations, then the `Nom` custom derive should be used.
+
+Additionally, calling the parsing methods requires the `Parse` trait, so callers must import it:
+```rust
+use nom_derive::Parse;
+```
+
+### Manual implementations of the `parse` method
+
+If you have manually implemented or called `parse` methods, you should convert them to implementations of the `Parse`
+trait.
+
+There are two possibilities:
+  - object does not depend on endianness: only the `parse` method of the trait should be implemented
+  - object has different representations: both `parse_be` and `parse_le` should be implemented
+
+For example:
+
+```rust
+impl OspfLinkStateAdvertisement {
+    pub fn parse(input: &[u8]) -> IResult<&[u8], OspfLinkStateAdvertisement> {
+        ...
+    }
+}
+```
+
+An OSPF packet is always represented as big-endian, so this becomes:
+
+```rust
+impl<'a> Parse<&'a [u8]> for OspfLinkStateAdvertisement {
+    fn parse(input: &'a [u8]) -> IResult<&'a [u8], OspfLinkStateAdvertisement> {
+        ...
+    }
+}
+```
+
+In most cases, that means only changing the `impl` statement and removing the `pub` keyword.
+
 ## Upgrading to 0.8
 
 ### The Parse trait

--- a/nom-derive-impl/src/config.rs
+++ b/nom-derive-impl/src/config.rs
@@ -15,7 +15,12 @@ pub struct Config {
     pub debug: bool,
     pub debug_derive: bool,
     pub generic_errors: bool,
-    pub input_name: String,
+    selector: Option<String>,
+    selector_name: Option<String>,
+    input_name: String,
+    orig_input_name: String,
+    lifetime_name: String,
+    error_name: String,
 }
 
 impl Config {
@@ -64,6 +69,18 @@ impl Config {
                 }
             })
             .unwrap_or_else(|| "i".to_string());
+        let selector = l.iter().find_map(|m| {
+            if m.is_type(MetaAttrType::Selector) {
+                Some(m.arg().unwrap().to_string())
+            } else {
+                None
+            }
+        });
+        let selector_name = if selector.is_some() {
+            Some(String::from("selector"))
+        } else {
+            None
+        };
         Ok(Config {
             struct_name: name,
             global_endianness: ParserEndianness::Unspecified,
@@ -72,7 +89,36 @@ impl Config {
             debug,
             debug_derive,
             generic_errors,
+            selector,
+            selector_name,
+            orig_input_name: "orig_".to_string() + &input_name,
+            lifetime_name: String::from("'nom"),
+            error_name: String::from("NomErr"),
             input_name,
         })
+    }
+
+    pub fn selector(&self) -> Option<&String> {
+        self.selector.as_ref()
+    }
+
+    pub fn selector_name(&self) -> Option<&String> {
+        self.selector_name.as_ref()
+    }
+
+    pub fn input_name(&self) -> &str {
+        &self.input_name
+    }
+
+    pub fn orig_input_name(&self) -> &str {
+        &self.orig_input_name
+    }
+
+    pub fn lifetime_name(&self) -> &str {
+        &self.lifetime_name
+    }
+
+    pub fn error_name(&self) -> &str {
+        &self.error_name
     }
 }

--- a/nom-derive-impl/src/gen.rs
+++ b/nom-derive-impl/src/gen.rs
@@ -1,62 +1,287 @@
 use crate::config::Config;
+use crate::endian::*;
+use crate::enums::impl_nom_enums;
+use crate::meta;
+use crate::meta::attr::{MetaAttr, MetaAttrType};
+use crate::structs::gen_struct_impl;
 use proc_macro2::{Span, TokenStream};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
 use syn::*;
 
-pub(crate) fn get_orig_input_name(config: &Config) -> Ident {
-    Ident::new(
-        &("orig_".to_string() + &config.input_name),
-        Span::call_site(),
-    )
-}
-
 pub(crate) fn gen_fn_decl(
-    generics: &Generics,
+    endianness: ParserEndianness,
     extra_args: Option<&TokenStream>,
     config: &Config,
 ) -> TokenStream {
-    let orig_input_name = get_orig_input_name(config);
+    let orig_input = Ident::new(config.orig_input_name(), Span::call_site());
+    let parse = match endianness {
+        ParserEndianness::BigEndian => "parse_be",
+        ParserEndianness::LittleEndian => "parse_le",
+        ParserEndianness::SetEndian => panic!("gen_fn_decl should never receive SetEndian"),
+        ParserEndianness::Unspecified => "parse",
+    };
+    let parse = Ident::new(parse, Span::call_site());
     // get lifetimes
-    let lft = Lifetime::new("'nom", Span::call_site());
-    let lfts: Vec<_> = generics.lifetimes().collect();
+    let lft = Lifetime::new(&config.lifetime_name(), Span::call_site());
     let mut fn_where_clause = WhereClause {
         where_token: Token![where](Span::call_site()),
         predicates: punctuated::Punctuated::new(),
     };
-    if !lfts.is_empty() {
-        // input slice must outlive all lifetimes from Self
-        let wh: WherePredicate = parse_quote! { #lft: #(#lfts)+* };
-        fn_where_clause.predicates.push(wh);
+    let mut fn_args: Punctuated<_, Token![,]> = Punctuated::new();
+    let arg_input: FnArg = parse_quote!(#orig_input: &#lft [u8]);
+    fn_args.push(arg_input);
+    // check extra args
+    if let Some(ts) = extra_args {
+        let ts = ts.clone();
+        let parser = Punctuated::<syn::FnArg, syn::Token![,]>::parse_separated_nonempty;
+        let extra_args = parser.parse2(ts).expect("parse extra_args");
+        for extra_arg in &extra_args {
+            fn_args.push(extra_arg.clone());
+        }
     };
     // function declaration line
     if config.generic_errors {
-        let ident_e = Ident::new("NomErr", Span::call_site());
-        // extend where clause for generic parameters
-        let dep: WherePredicate = parse_quote! {
-            #ident_e: nom_derive::nom::error::ParseError<&#lft [u8]>
-        };
-        fn_where_clause.predicates.push(dep);
-        // make sure generic parameters inplement Parse
-        for param in generics.type_params() {
-            let param_ident = &param.ident;
-            let dep: WherePredicate = parse_quote! { #param_ident: Parse<&#lft [u8], #ident_e> };
+        let ident_e = Ident::new(config.error_name(), Span::call_site());
+        let mut fn_generics = None;
+        if extra_args.is_some() || config.selector().is_some() {
+            // special case: not implementing the Parse trait,
+            // generic errors must be added to function, not struct
+            //
+            // extend where clause for generic parameters
+            let dep: WherePredicate = parse_quote! {
+                #ident_e: nom_derive::nom::error::ParseError<&#lft [u8]>
+            };
             fn_where_clause.predicates.push(dep);
+            let dep: WherePredicate = parse_quote! { #ident_e: std::fmt::Debug };
+            fn_where_clause.predicates.push(dep);
+            // add error type to function generics
+            fn_generics = Some(quote!(<#ident_e>));
         }
-        // let dep: WherePredicate = parse_quote! { #ident_e: std::fmt::Debug };
-        // fn_where_clause.predicates.push(dep);
         quote! {
-            pub fn parse<#lft, #ident_e>(#orig_input_name: &#lft [u8] #extra_args) -> nom::IResult<&#lft [u8], Self, #ident_e>
+            fn #parse#fn_generics(#fn_args) -> nom::IResult<&#lft [u8], Self, #ident_e>
             #fn_where_clause
         }
     } else {
-        // make sure generic parameters inplement Parse
-        for param in generics.type_params() {
-            let param_ident = &param.ident;
-            let dep: WherePredicate = parse_quote! { #param_ident: Parse<&#lft [u8]> };
-            fn_where_clause.predicates.push(dep);
-        }
         quote! {
-            pub fn parse<#lft>(#orig_input_name: &#lft [u8] #extra_args) -> nom::IResult<&#lft [u8], Self>
+            fn #parse(#fn_args) -> nom::IResult<&#lft [u8], Self>
             #fn_where_clause
         }
     }
+}
+
+pub(crate) fn get_extra_args(meta_list: &[MetaAttr]) -> Option<&proc_macro2::TokenStream> {
+    meta_list
+        .iter()
+        .find(|m| m.attr_type == MetaAttrType::ExtraArgs)
+        .and_then(MetaAttr::arg)
+}
+
+pub(crate) fn gen_impl(
+    ast: &syn::DeriveInput,
+    debug_derive: bool,
+    endianness: ParserEndianness,
+) -> Result<TokenStream> {
+    // eprintln!("ast: {:#?}", ast);
+    let struct_name = ast.ident.to_string();
+    // parse top-level attributes and prepare tokens for each field parser
+    let meta = meta::parse_nom_top_level_attribute(&ast.attrs)?;
+    // eprintln!("top-level meta: {:?}", meta);
+    let mut config = Config::from_meta_list(struct_name, &meta)?;
+    config.debug_derive |= debug_derive;
+    let orig_input = Ident::new(config.orig_input_name(), Span::call_site());
+    let lft = Lifetime::new(config.lifetime_name(), Span::call_site());
+    let ident_e = Ident::new(config.error_name(), Span::call_site());
+    set_object_endianness(ast.ident.span(), endianness, &meta, &mut config)?;
+    let extra_args = get_extra_args(&meta);
+    // build function args
+    let mut fn_args: Punctuated<_, Token![,]> = Punctuated::new();
+    let arg_input: FnArg = parse_quote!(#orig_input: &#lft [u8]);
+    fn_args.push(arg_input);
+    // build call_args from extra_args
+    let mut call_args: Punctuated<_, Token![,]> = Punctuated::new();
+    // check selector
+    call_args.push(orig_input);
+    match (config.selector(), config.selector_name()) {
+        (Some(sel_type), Some(s)) => {
+            let selector = Ident::new(s, Span::call_site());
+            let sel_type = Ident::new(sel_type, Span::call_site());
+            let selector_arg: FnArg = parse_quote!(#selector: #sel_type);
+            fn_args.push(selector_arg);
+            call_args.push(selector);
+        }
+        (None, None) => (),
+        (_, _) => panic!("Impossible configuration for 'selector'"),
+    }
+    // check extra args
+    if let Some(ts) = extra_args {
+        let ts = ts.clone();
+        let parser = Punctuated::<syn::FnArg, syn::Token![,]>::parse_separated_nonempty;
+        let extra_args = parser.parse2(ts).expect("parse extra_args");
+        for extra_arg in &extra_args {
+            fn_args.push(extra_arg.clone());
+            match extra_arg {
+                syn::FnArg::Receiver(_) => panic!("self should not be used in extra_args"),
+                syn::FnArg::Typed(t) => {
+                    if let syn::Pat::Ident(pat_ident) = t.pat.as_ref() {
+                        call_args.push(pat_ident.ident.clone());
+                    } else {
+                        panic!("unexpected pattern in extra_args");
+                    }
+                }
+            }
+        }
+    };
+
+    // XXX if Error type is not used (not a parse Trait), it should be moved to the function
+
+    // generate trait:
+    //   get forced endianness, if any
+    //   if forced endianness(ex: be): gen only parse_be, and make other points to parse_be
+    //   if !forced: gen parse_le and parse_be
+    let endianness = get_object_endianness(&config);
+    // big-endian
+    let tokens_parse_be = if endianness != ParserEndianness::LittleEndian {
+        match &ast.data {
+            syn::Data::Enum(_) => {
+                impl_nom_enums(ast, &meta, ParserEndianness::BigEndian, &mut config)?
+            }
+            syn::Data::Struct(_) => {
+                gen_struct_impl(ast, &meta, ParserEndianness::BigEndian, &mut config)?
+            }
+            syn::Data::Union(_) => panic!("Unions not supported"),
+        }
+    } else {
+        // generate stub to call parse_le
+        let fn_decl = gen_fn_decl(ParserEndianness::BigEndian, None, &config);
+        quote! {
+            #fn_decl {
+                Self::parse_le(#call_args)
+            }
+        }
+    };
+    // little-endian
+    let tokens_parse_le = if endianness != ParserEndianness::BigEndian {
+        match &ast.data {
+            syn::Data::Enum(_) => {
+                impl_nom_enums(ast, &meta, ParserEndianness::LittleEndian, &mut config)?
+            }
+            syn::Data::Struct(_) => {
+                gen_struct_impl(ast, &meta, ParserEndianness::LittleEndian, &mut config)?
+            }
+            syn::Data::Union(_) => panic!("Unions not supported"),
+        }
+    } else {
+        // generate stub to call parse_be
+        let fn_decl = gen_fn_decl(ParserEndianness::LittleEndian, None, &config);
+        quote! {
+            #fn_decl {
+                Self::parse_be(#call_args)
+            }
+        }
+    };
+
+    // 'parse' function
+    let maybe_err = if config.generic_errors {
+        quote!( , #ident_e )
+    } else {
+        quote!()
+    };
+    let tokens_parse = {
+        let (fn_generics, where_clause) =
+            if config.generic_errors && (extra_args.is_some() || config.selector().is_some()) {
+                (
+                    quote!(<#ident_e>),
+                    quote! {where
+                        #ident_e: nom_derive::nom::error::ParseError<&#lft [u8]>,
+                        #ident_e: std::fmt::Debug,
+                    },
+                )
+            } else {
+                (quote!(), quote!())
+            };
+        quote! {
+            fn parse#fn_generics(#fn_args) -> nom::IResult<&'nom [u8], Self #maybe_err> #where_clause {
+                Self::parse_be(#call_args)
+            }
+        }
+    };
+
+    // combine everything
+
+    let name = &ast.ident;
+    // extract impl parameters from struct
+    let orig_generics = &ast.generics;
+    let (impl_generics, ty_generics, where_clause) = orig_generics.split_for_impl();
+
+    let mut gen_impl: Generics = parse_quote!(#impl_generics);
+    gen_impl
+        .params
+        .push(GenericParam::Lifetime(LifetimeDef::new(lft.clone())));
+    let param_e = TypeParam::from(ident_e.clone());
+
+    let mut gen_wh: WhereClause = if where_clause.is_none() {
+        parse_quote!(where)
+    } else {
+        parse_quote!(#where_clause)
+    };
+    let lfts: Vec<_> = ast.generics.lifetimes().collect();
+    if !lfts.is_empty() {
+        // input slice must outlive all lifetimes from Self
+        let wh: WherePredicate = parse_quote! { #lft: #(#lfts)+* };
+        gen_wh.predicates.push(wh);
+    };
+
+    // make sure generic parameters inplement Parse
+    for param in ast.generics.type_params() {
+        let param_ident = &param.ident;
+        let dep: WherePredicate = parse_quote! { #param_ident: Parse< &#lft [u8] #maybe_err > };
+        gen_wh.predicates.push(dep);
+    }
+
+    // Global impl
+    let impl_tokens = if extra_args.is_some() || config.selector().is_some() {
+        // There are extra arguments, so we can't generate the Parse impl
+        // Generate an equivalent implementation
+        if config.generic_errors {
+            // XXX will fail: generic type should be added to function (npt struct), or
+            // XXX compiler will complain that
+            // XXX "the type parameter `NomErr` is not constrained by the impl trait, self type, or predicates"
+            // this happens only when not implementing trait (the trait constrains NomErr)
+            // let wh: WherePredicate = parse_quote!(#ident_e: nom::error::ParseError<& #lft [u8]>);
+            // gen_wh.predicates.push(wh);
+            // gen_impl.params.push(GenericParam::Type(param_e));
+        }
+        quote! {
+            impl #gen_impl #name #ty_generics #gen_wh {
+                #tokens_parse_be
+                #tokens_parse_le
+                #tokens_parse
+            }
+        }
+    } else {
+        // Generate an impl block for the Parse trait
+        let error;
+        if config.generic_errors {
+            let wh: WherePredicate = parse_quote!(#ident_e: nom::error::ParseError<& #lft [u8]>);
+            gen_wh.predicates.push(wh);
+            gen_impl.params.push(GenericParam::Type(param_e));
+            error = quote! { #ident_e };
+        } else {
+            error = quote! { nom::error::Error<&#lft [u8]> };
+        }
+        quote! {
+                impl #gen_impl nom_derive::Parse<& #lft [u8], #error> for #name #ty_generics #gen_wh {
+                    #tokens_parse_be
+                    #tokens_parse_le
+                    #tokens_parse
+                }
+
+        }
+    };
+    // eprintln!("\n***\nglobal_impl: {}\n---\n", impl_tokens);
+    if config.debug_derive {
+        eprintln!("tokens:\n{}", impl_tokens);
+    }
+    Ok(impl_tokens)
 }

--- a/nom-derive-impl/src/meta/attr.rs
+++ b/nom-derive-impl/src/meta/attr.rs
@@ -235,8 +235,7 @@ impl Parse for MetaAttr {
                     let _paren_token = parenthesized!(content in input);
                     type ExpectedType = Punctuated<syn::Field, Token![,]>;
                     let fields: ExpectedType = content.parse_terminated(syn::Field::parse_named)?;
-                    // prepend comma, args will be after input name
-                    quote! { , #fields }
+                    quote! { #fields }
                 }
                 MetaAttrType::PreExec | MetaAttrType::PostExec => {
                     parse_content::<syn::Stmt>(input)?

--- a/nom-derive-impl/src/parsertree.rs
+++ b/nom-derive-impl/src/parsertree.rs
@@ -43,7 +43,6 @@ pub enum ParserExpr {
     DbgDmp(Box<ParserExpr>, Ident),
     Into(Box<ParserExpr>),
     LengthCount(Box<ParserExpr>, TokenStream),
-    Many0(Box<ParserExpr>),
     Map(Box<ParserExpr>, TokenStream),
     Nop,
     PhantomData,
@@ -93,9 +92,6 @@ impl ToTokens for ParserExpr {
             }
             ParserExpr::LengthCount(expr, n) => {
                 quote! { nom::multi::length_count(#n, #expr) }
-            }
-            ParserExpr::Many0(expr) => {
-                quote! { nom::multi::many0(#expr) }
             }
             ParserExpr::Map(expr, m) => {
                 quote! { nom::combinator::map(#expr, #m) }

--- a/nom-derive-impl/src/structs.rs
+++ b/nom-derive-impl/src/structs.rs
@@ -50,19 +50,8 @@ pub(crate) fn get_extra_args(meta_list: &[MetaAttr]) -> Option<&TokenStream> {
 fn get_type_parser(ty: &Type, meta_list: &[MetaAttr], config: &Config) -> Result<ParserExpr> {
     // special case: PhantomData
     let ident = get_type_first_ident(ty)?;
-    match ident.as_ref() {
-        "PhantomData" => {
-            return Ok(ParserExpr::PhantomData);
-        }
-        "Vec" => {
-            let sub = get_item_subtype_parser(ty, "Vec", "Vec")?;
-            let sub_ty = syn::parse2::<Type>(sub)?;
-            // force sub_meta_list to be empty, so attributes are not used
-            let expr = get_parser(None, &sub_ty, &[], meta_list, config)?;
-            let p = ParserExpr::Complete(Box::new(expr));
-            return Ok(ParserExpr::Many0(Box::new(p)));
-        }
-        _ => (),
+    if ident == "PhantomData" {
+        return Ok(ParserExpr::PhantomData);
     }
     let endian = get_local_endianness(ty.span(), meta_list, config)?;
     match endian {
@@ -163,8 +152,6 @@ fn get_parser(
     // first check if we have attributes set
     // eprintln!("attrs: {:?}", field.attrs);
     // eprintln!("meta_list: {:?}", meta_list);
-    // eprintln!("sub_meta_list (before loop): {:?}", sub_meta_list);
-    // eprintln!("ty (before loop): {:?}", ty);
     let mut sub_meta_list = sub_meta_list;
     while let Some((meta, rem)) = sub_meta_list.split_first() {
         sub_meta_list = rem;

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -408,7 +408,7 @@
 /// # assert_eq!(res, Ok((&input[4..],S{a:0,b:S2{c:1}})));
 /// ```
 ///
-/// Example (defining `parse` method):
+/// Example (implementing the `Parse` trait manually):
 /// ```rust
 /// # use nom_derive::*;
 /// # use nom::{IResult,call,map};
@@ -420,8 +420,8 @@
 ///   c: u16
 /// }
 ///
-/// impl S2 {
-///     fn parse(i:&[u8]) -> IResult<&[u8],S2> {
+/// impl<'a> Parse<&'a[u8]> for S2 {
+///     fn parse(i:&'a [u8]) -> IResult<&'a [u8],S2> {
 ///         map!(
 ///             i,
 ///             le_u16, // little-endian

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,20 +51,33 @@
 //! }
 //! ```
 //!
-//! This adds static method `parse` to `S`. The generated code looks
-//! like:
+//! This generates an implementation of the [`Parse`] trait to `S`. The generated code looks
+//! like (code simplified):
 //! ```rust,ignore
-//! impl S {
-//!     pub fn parse(i: &[u8]) -> nom::IResult(&[u8], S) {
+//! impl<'a> Parse<&'a> for S {
+//!     pub fn parse_be(i: &'a [u8]) -> nom::IResult(&'a [u8], S) {
 //!         let (i, a) = be_u32(i)?;
 //!         let (i, b) = be_u16(i)?;
 //!         let (i, c) = be_u16(i)?;
 //!         Ok((i, S{ a, b, c }))
 //!     }
+//!     pub fn parse_le(i: &'a [u8]) -> nom::IResult(&'a [u8], S) {
+//!         let (i, a) = le_u32(i)?;
+//!         let (i, b) = le_u16(i)?;
+//!         let (i, c) = le_u16(i)?;
+//!         Ok((i, S{ a, b, c }))
+//!     }
+//!     pub fn parse(i: &'a [u8]) -> nom::IResult(&'a [u8], S) {
+//!         S::parse_be(i)
+//!     }
 //! }
 //! ```
 //!
-//! To parse input, just call `let res = S::parse(input);`.
+//! To parse input, just call `let res = S::parse_be(input);`.
+//!
+//! If the endianness of the struct is fixed (for ex. using the top-level `BigEndian` or
+//! `LittleEndian` attributes, or the `NomBE` and `NomLE` custom derive), then the implementation
+//! always uses this endianness, and all 3 functions are equivalent.
 //!
 //! For extensive documentation of all attributes and examples, see the documentation of [docs::Nom]
 //! custom derive attribute.

--- a/tests/compile-fail/unsupported_types.rs
+++ b/tests/compile-fail/unsupported_types.rs
@@ -3,6 +3,7 @@ extern crate nom_derive;
 use nom_derive::Nom;
 use std::collections::HashMap;
 
+// multiple errors, HashMap does not implement Parse
 #[derive(Nom)]
 pub struct S1 {
     h: HashMap<u64, u64>,

--- a/tests/compile-fail/unsupported_types.stderr
+++ b/tests/compile-fail/unsupported_types.stderr
@@ -1,13 +1,21 @@
 error: Nom-derive: multiple segments in type path are not supported
-  --> $DIR/unsupported_types.rs:13:8
+  --> $DIR/unsupported_types.rs:14:8
    |
-13 |     h: ::std::primitive::u64, // ERROR: Nom-derive: multiple segments in type path are not supported
+14 |     h: ::std::primitive::u64, // ERROR: Nom-derive: multiple segments in type path are not supported
    |        ^^
 
-error[E0599]: no function or associated item named `parse` found for struct `HashMap<u64, u64>` in the current scope
- --> $DIR/unsupported_types.rs:6:10
+error[E0599]: no function or associated item named `parse_be` found for struct `HashMap<u64, u64>` in the current scope
+ --> $DIR/unsupported_types.rs:7:10
   |
-6 | #[derive(Nom)]
+7 | #[derive(Nom)]
+  |          ^^^ function or associated item not found in `HashMap<u64, u64>`
+  |
+  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0599]: no function or associated item named `parse_le` found for struct `HashMap<u64, u64>` in the current scope
+ --> $DIR/unsupported_types.rs:7:10
+  |
+7 | #[derive(Nom)]
   |          ^^^ function or associated item not found in `HashMap<u64, u64>`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/lifetimes.rs
+++ b/tests/lifetimes.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use nom_derive::Nom;
+use nom_derive::*;
 
 use nom::bytes::complete::take;
 use nom::combinator::map;

--- a/tests/run-pass/custom-errors-enum.rs
+++ b/tests/run-pass/custom-errors-enum.rs
@@ -1,5 +1,6 @@
 use nom_derive::nom::bytes::streaming::take;
-use nom_derive::nom::error::VerboseError;
+use nom_derive::nom::error::{Error, VerboseError};
+use nom_derive::nom::IResult;
 use nom_derive::*;
 
 /// unnamed struct
@@ -73,6 +74,6 @@ fn main() {
     assert_eq!(rem, (&input[5..], U4::Field1(b"\x01\x02\x03\x04")));
 
     // test fieldless enum and error type: unit
-    let rem = U6::parse::<()>(&input[2..]).unwrap();
-    assert_eq!(rem, (&input[3..], U6::B));
+    let rem: IResult<_, _, Error<_>> = U6::parse(&input[2..]);
+    assert_eq!(rem.unwrap(), (&input[3..], U6::B));
 }

--- a/tests/run-pass/custom-errors.rs
+++ b/tests/run-pass/custom-errors.rs
@@ -1,4 +1,5 @@
 use nom_derive::nom::error::VerboseError;
+use nom_derive::nom::IResult;
 use nom_derive::*;
 
 #[derive(Nom, Debug, PartialEq)]
@@ -32,17 +33,17 @@ fn main() {
     let input: &[u8] = b"\x00\x01\x02\x03\x04\x05\x06\x07";
 
     // test error type: unit
-    let rem = S1::parse::<()>(input).unwrap();
-    assert_eq!(rem, (&input[4..], S1 { a: 0x10203 }));
+    let rem: IResult<_, _, ()> = S1::parse(input);
+    assert_eq!(rem.unwrap(), (&input[4..], S1 { a: 0x10203 }));
 
     // test error type: VerboseError
-    let rem = S1::parse::<VerboseError<_>>(input).unwrap();
-    assert_eq!(rem, (&input[4..], S1 { a: 0x10203 }));
+    let rem: IResult<_, _, VerboseError<_>> = S1::parse(input);
+    assert_eq!(rem.unwrap(), (&input[4..], S1 { a: 0x10203 }));
 
     // test lifetimes and error type: VerboseError
-    let rem = StructWithLifetime::parse::<VerboseError<_>>(input).unwrap();
+    let rem: IResult<_, _, VerboseError<_>> = StructWithLifetime::parse(input);
     assert_eq!(
-        rem,
+        rem.unwrap(),
         (
             &input[4..],
             StructWithLifetime {
@@ -53,9 +54,9 @@ fn main() {
     );
 
     // test two lifetimes and error type: VerboseError
-    let rem = StructWithTwoLifetimes::parse::<VerboseError<_>>(input).unwrap();
+    let rem: IResult<_, _, VerboseError<_>> = StructWithTwoLifetimes::parse(input);
     assert_eq!(
-        rem,
+        rem.unwrap(),
         (
             &input[8..],
             StructWithTwoLifetimes {

--- a/tests/run-pass/enum-fieldless.rs
+++ b/tests/run-pass/enum-fieldless.rs
@@ -1,5 +1,5 @@
 use nom::number::streaming::be_u8;
-use nom_derive::Nom;
+use nom_derive::*;
 
 /// A fieldless enum, using the 'Selector' attribute
 ///

--- a/tests/run-pass/generics.rs
+++ b/tests/run-pass/generics.rs
@@ -1,4 +1,5 @@
 use nom_derive::nom::error::VerboseError;
+use nom_derive::nom::IResult;
 use nom_derive::*;
 
 /// A struct with a generic parameter
@@ -28,16 +29,16 @@ fn main() {
     assert_eq!(rem, (&input[4..], StructWithGenerics { t: 0x10203u32 }));
 
     // test generics: u16 and custom error: unit
-    let rem = StructWithGenericsAndErrors::<u16>::parse::<()>(input).unwrap();
+    let rem: IResult<_, _, ()> = StructWithGenericsAndErrors::<u16>::parse(input);
     assert_eq!(
-        rem,
+        rem.unwrap(),
         (&input[2..], StructWithGenericsAndErrors { t: 0x1u16 })
     );
 
     // test generics: u16 and custom error: VerboseError
-    let rem = StructWithGenericsAndErrors::<u16>::parse::<VerboseError<_>>(input).unwrap();
+    let rem: IResult<_, _, VerboseError<_>> = StructWithGenericsAndErrors::<u16>::parse(input);
     assert_eq!(
-        rem,
+        rem.unwrap(),
         (&input[2..], StructWithGenericsAndErrors { t: 0x1u16 })
     );
 }

--- a/tests/run-pass/into.rs
+++ b/tests/run-pass/into.rs
@@ -1,0 +1,33 @@
+use nom::character::streaming::alpha1;
+use nom::IResult;
+use nom_derive::*;
+
+fn parser1(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    alpha1(i)
+}
+
+#[derive(Debug, PartialEq, NomBE)]
+// #[nom(DebugDerive)]
+struct IntoStruct {
+    #[nom(Into, Parse = "parser1")]
+    a: Vec<u8>,
+    b: u16,
+    c: u16,
+}
+
+fn main() {
+    let input = b"abcd\x00\x01\x00\x02";
+
+    let res = IntoStruct::parse(input);
+    assert_eq!(
+        res,
+        Ok((
+            &input[8..],
+            IntoStruct {
+                a: vec![97, 98, 99, 100],
+                b: 1,
+                c: 2,
+            }
+        ))
+    )
+}


### PR DESCRIPTION
This PR implements the automatic generation of the `Parse` trait, when possible.
Generate implementation of Parse trait when possible. The code now generates 3 functions instead of one (parse):
- parse_be: parse object as big-endian
- parse_le: parse object as little-endian
- parse: default function, wraps a call to parse_be
    
If the endianness of the struct is fixed, then all 3 functions are equivalent.
    
This helps generalizing the use of the Parse trait.
    
When there are extra args or a selector, it is not possible to generate the trait implementation (function signatures are different). In that case, an implementation block is generate with the 3 functions.
    
The code had to be refactored to generate several methods, and to be able to handle some tricky corner cases, like generating code that compiles, with trait generics/where clauses and function generics/where clauses, that is accepted by the compiler.

Documentation and upgrade instructions were added.

Closes #21, closes #24