### PR TITLE
Make no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,15 @@ include = [
 members = ["nom-derive-impl"]
 
 [dependencies]
-nom = "6.0"
+nom = {version = "6.0", default-features = false, features=["alloc"]}
 nom-derive-impl = { version="=0.9.1", path="./nom-derive-impl" }
 rustversion = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7"
 trybuild = "1.0"
+
+[features]
+alloc = []
+default = ["std"]
+std = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ include = [
 members = ["nom-derive-impl"]
 
 [dependencies]
-nom = {version = "6.0", default-features = false, features=["alloc"]}
+nom = {version = "6.0", default-features = false}
 nom-derive-impl = { version="=0.9.1", path="./nom-derive-impl" }
 rustversion = "1.0"
 
@@ -38,6 +38,6 @@ pretty_assertions = "0.7"
 trybuild = "1.0"
 
 [features]
-alloc = []
+alloc = ["nom/alloc"]
 default = ["std"]
-std = ["alloc"]
+std = ["alloc", "nom/std"]

--- a/nom-derive-impl/src/gen.rs
+++ b/nom-derive-impl/src/gen.rs
@@ -60,7 +60,7 @@ pub(crate) fn gen_fn_decl(
                 #ident_e: nom_derive::nom::error::ParseError<&#lft [u8]>
             };
             fn_where_clause.predicates.push(dep);
-            let dep: WherePredicate = parse_quote! { #ident_e: std::fmt::Debug };
+            let dep: WherePredicate = parse_quote! { #ident_e: core::fmt::Debug };
             fn_where_clause.predicates.push(dep);
             // add error type to function generics
             fn_generics = Some(quote!(<#ident_e>));

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 use crate::traits::*;
+use core::marker::PhantomData;
 use nom::error::ParseError;
 use nom::{IResult, ToUsize};
-use core::marker::PhantomData;
 
 #[derive(Debug, PartialEq)]
 pub struct LengthData<L, D> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 use crate::traits::*;
 use nom::error::ParseError;
 use nom::{IResult, ToUsize};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[derive(Debug, PartialEq)]
 pub struct LengthData<L, D> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@
 //!   `stderr` if the parser fails.
 //!
 //! [nom]: https://github.com/geal/nom
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 pub mod docs;
 mod helpers;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,8 +5,18 @@ use nom::multi::{many0, many_m_n};
 use nom::number::streaming::*;
 use nom::sequence::pair;
 use nom::*;
-use std::convert::TryFrom;
-use std::ops::RangeFrom;
+use core::convert::TryFrom;
+use core::ops::RangeFrom;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::{
+    vec::Vec, 
+    string::String,
+    borrow::ToOwned,
+};
 
 pub use nom::{InputLength, Slice};
 
@@ -152,11 +162,11 @@ impl_primitive_type!(f64, be_f64, le_f64);
 
 impl<'a, E> Parse<&'a [u8], E> for String
 where
-    E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], std::str::Utf8Error>,
+    E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], core::str::Utf8Error>,
 {
     fn parse(i: &'a [u8]) -> IResult<&'a [u8], Self, E> {
         let (rem, sz) = <u32>::parse(i)?;
-        let (rem, s) = map_res(take(sz as usize), std::str::from_utf8)(rem)?;
+        let (rem, s) = map_res(take(sz as usize), core::str::from_utf8)(rem)?;
         Ok((rem, s.to_owned()))
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,5 @@
+use core::convert::TryFrom;
+use core::ops::RangeFrom;
 use nom::bytes::streaming::take;
 use nom::combinator::{complete, map_res, opt};
 use nom::error::{Error, FromExternalError, ParseError};
@@ -5,18 +7,12 @@ use nom::multi::{many0, many_m_n};
 use nom::number::streaming::*;
 use nom::sequence::pair;
 use nom::*;
-use core::convert::TryFrom;
-use core::ops::RangeFrom;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-use alloc::{
-    vec::Vec, 
-    string::String,
-    borrow::ToOwned,
-};
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
 
 pub use nom::{InputLength, Slice};
 


### PR DESCRIPTION
This PR is a WIP for making the crate `no_std` compatible.

I would like to use nom-derive in a no_std context, and have the following attempt below.  

- It compiles and builds for my embedded target.
- It passes the same `cargo test` results as the current master

I'm not sure of the larger context for how you'd like the crate to operate.  Thought I'd pass along the "request for feature".