### PR TITLE
Fix endian-neutral parsers that use attributes

### DIFF
--- a/nom-derive-impl/src/parsertree.rs
+++ b/nom-derive-impl/src/parsertree.rs
@@ -70,6 +70,30 @@ impl ParserExpr {
                 ParserEndianness::LittleEndian => ParserExpr::CallParseLE(item.clone()),
                 _ => unreachable!(),
             },
+            ParserExpr::Complete(expr) => {
+                ParserExpr::Complete(expr.with_endianness(endianness).into())
+            }
+            ParserExpr::Cond(expr, c) => {
+                ParserExpr::Cond(expr.with_endianness(endianness).into(), c.clone())
+            }
+            ParserExpr::Count(expr, n) => {
+                ParserExpr::Count(expr.with_endianness(endianness).into(), n.clone())
+            }
+            ParserExpr::DbgDmp(expr, i) => {
+                ParserExpr::DbgDmp(expr.with_endianness(endianness).into(), i.clone())
+            }
+            ParserExpr::Into(expr) => ParserExpr::Into(expr.with_endianness(endianness).into()),
+            ParserExpr::LengthCount(expr, n) => {
+                ParserExpr::LengthCount(expr.with_endianness(endianness).into(), n.clone())
+            }
+            ParserExpr::Map(expr, m) => {
+                ParserExpr::Map(expr.with_endianness(endianness).into(), m.clone())
+            }
+            ParserExpr::Verify(expr, i, v) => ParserExpr::Verify(
+                expr.with_endianness(endianness).into(),
+                i.clone(),
+                v.clone(),
+            ),
             expr => expr.clone(),
         }
     }

--- a/tests/run-pass/nested-attributes.rs
+++ b/tests/run-pass/nested-attributes.rs
@@ -40,6 +40,18 @@ fn main() {
         ))
     );
 
+    let res = OptionVecS1::parse_le(input);
+    assert_eq!(
+        res,
+        Ok((
+            &input[16..],
+            OptionVecS1 {
+                a: 0x400,
+                b: Some(vec![0x100, 0x3412, 0x7856, 0x3412, 0x7856, 0, 0x100])
+            }
+        ))
+    );
+
     let res = OptionVecS2::parse(input);
     assert_eq!(
         res,
@@ -52,6 +64,18 @@ fn main() {
         ))
     );
 
+    let res = OptionVecS2::parse_le(input);
+    assert_eq!(
+        res,
+        Ok((
+            &input[16..],
+            OptionVecS2 {
+                a: 0x400,
+                b: Some(vec![0x100, 0x3412, 0x7856, 0x3412, 0x7856, 0, 0x100])
+            }
+        ))
+    );
+
     let res = OptionVecS3::parse(input);
     assert_eq!(
         res,
@@ -60,6 +84,18 @@ fn main() {
             OptionVecS3 {
                 a: 4,
                 b: Some(vec![1, 0x1234, 0x5678, 0x1234])
+            }
+        ))
+    );
+
+    let res = OptionVecS3::parse_le(input);
+    assert_eq!(
+        res,
+        Ok((
+            &input[10..],
+            OptionVecS3 {
+                a: 0x400,
+                b: Some(vec![0x100, 0x3412, 0x7856, 0x3412])
             }
         ))
     );


### PR DESCRIPTION
Normally, when using the `Nom` derive, `parse_le` delegates to `parse_le`, and `parse_be` delegates to `parse_be`. This allows the parser to be endian-neutral.

However, when using attributes, this is no longer the case, and both `parse_le` and `parse_be` delegate to `parse`. For example, for the below struct, `MyStruct::parse_le` and `MyStruct::parse_be` will both parse the `u32` as big-endian:

```rust
#[derive(Nom)]
struct MyStruct(#[nom(Complete)] u32);
```