### PR TITLE
dependency: do not use syn 2

### DIFF
--- a/nom-derive-impl/Cargo.toml
+++ b/nom-derive-impl/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 proc-macro = true
 
 [dependencies]
-syn = { version=">=1.0.58", features=["parsing","extra-traits","full"] }
+syn = { version="1.0.58", features=["parsing","extra-traits","full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
@pc-anssi Suricata is not building because of error
```
   Compiling nom-derive-impl v0.10.0
error[E0433]: failed to resolve: could not find `NestedMeta` in `syn`
  --> /Users/catena/.cargo/registry/src/github.com-1ecc6299db9ec823/nom-derive-impl-0.10.0/src/enums.rs:70:42
   |
70 | ...                   syn::NestedMeta::Meta(meta) => match meta {
   |                            ^^^^^^^^^^ could not find `NestedMeta` in `syn`
```

See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html