### PR TITLE
feat: Add no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,11 @@ jobs:
           - stable
           - 1.65.0
           - nightly
+
+        features:
+          - ''
+          - '--no-default-features'
+          - '--no-default-features --features "alloc"'
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,6 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: ${{ matrix.features }}
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,15 @@ include = [
 members = ["nom-derive-impl"]
 
 [dependencies]
-nom = { version = "8.0", default-features = false, features = ["std"] }
+nom = { version = "8.0", default-features = false }
 nom-derive-impl = { version = "=0.11.0", path = "./nom-derive-impl" }
 rustversion = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4"
 trybuild = "1.0"
+
+[features]
+alloc = ["nom/alloc"]
+default = ["std"]
+std = ["alloc", "nom/std"]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,7 @@
 use crate::traits::*;
+use core::marker::PhantomData;
 use nom::error::ParseError;
 use nom::{IResult, ToUsize};
-use std::marker::PhantomData;
 
 #[derive(Debug, PartialEq)]
 pub struct LengthData<L, D> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@
 //!
 //! [nom]: https://github.com/geal/nom
 
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
 pub mod docs;
 mod helpers;
 mod traits;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,11 +1,29 @@
-use nom::bytes::streaming::take;
-use nom::combinator::{complete, map_res, opt};
-use nom::error::{Error, FromExternalError, ParseError};
-use nom::multi::{many0, many_m_n};
+use nom::combinator::{complete, opt};
+use nom::error::{Error, ParseError};
 use nom::number::streaming::*;
 use nom::sequence::pair;
 use nom::*;
-use std::convert::TryFrom;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+
+#[cfg(feature = "alloc")]
+use core::convert::TryFrom;
+
+#[cfg(feature = "alloc")]
+use nom::bytes::streaming::take;
+
+#[cfg(feature = "alloc")]
+use nom::combinator::map_res;
+
+#[cfg(feature = "alloc")]
+use nom::error::FromExternalError;
+
+#[cfg(feature = "alloc")]
+use nom::multi::{many0, many_m_n};
 
 pub trait InputSlice: Input<Item = u8> {}
 impl InputSlice for &[u8] {}
@@ -144,13 +162,14 @@ impl_primitive_type!(u128, be_u128, le_u128);
 impl_primitive_type!(f32, be_f32, le_f32);
 impl_primitive_type!(f64, be_f64, le_f64);
 
+#[cfg(feature = "alloc")]
 impl<'a, E> Parse<&'a [u8], E> for String
 where
-    E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], std::str::Utf8Error>,
+    E: ParseError<&'a [u8]> + FromExternalError<&'a [u8], core::str::Utf8Error>,
 {
     fn parse(i: &'a [u8]) -> IResult<&'a [u8], Self, E> {
         let (rem, sz) = <u32>::parse(i)?;
-        let (rem, s) = map_res(take(sz as usize), std::str::from_utf8).parse(rem)?;
+        let (rem, s) = map_res(take(sz as usize), core::str::from_utf8).parse(rem)?;
         Ok((rem, s.to_owned()))
     }
 }
@@ -172,6 +191,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<T, I, E> Parse<I, E> for Vec<T>
 where
     I: Clone + PartialEq + InputSlice,
@@ -209,6 +229,7 @@ where
 
 /// *Note: this implementation uses const generics and requires rust >= 1.51*
 #[rustversion::since(1.51)]
+#[cfg(feature = "alloc")]
 impl<T, I, E, const N: usize> Parse<I, E> for [T; N]
 where
     I: Clone + PartialEq + InputSlice,


### PR DESCRIPTION
Follow-on from https://github.com/rust-bakery/nom-derive/pull/33.

Adds `no_std` support, and adjusts GitHub actions workflow to check these cases as well.

Tested against `thumbv7em-none-eabi` target.